### PR TITLE
removed a duplicate import for ArticleCoverImageComponent

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -121,7 +121,6 @@ import { AllArticlesComponent } from './all-articles/all-articles.component';
     AddReplyComponent,
     EditCommentComponent,
     TimeElapsedPipe,
-    ArticleCoverImageComponent,
     UploadFormComponent,
     AllArticlesComponent
   ],


### PR DESCRIPTION
I cloned down a fresh repo to start the work day, when I went to serve the app, it threw me an error and said that there was a duplicate import on the app.module. So, per Kyle's instruction, I branched out, mad the fix, pushed and made a pull request! 